### PR TITLE
fix: resolve MissingMethodException on Jellyfin 10.11.10

### DIFF
--- a/Jellyfin.Plugin.TopTen/Jellyfin.Plugin.TopTen.csproj
+++ b/Jellyfin.Plugin.TopTen/Jellyfin.Plugin.TopTen.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.10" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.TopTen/ScheduledTasks/TopTenCollectionTask.cs
+++ b/Jellyfin.Plugin.TopTen/ScheduledTasks/TopTenCollectionTask.cs
@@ -114,7 +114,7 @@ namespace Jellyfin.Plugin.TopTen.ScheduledTasks
                 await CleanupRenamedCollectionAsync(config, cancellationToken).ConfigureAwait(false);
 
                 // Get all users
-                var users = _userManager.Users.ToList();
+                var users = _userManager.GetUsers().ToList();
                 
                 // Get top movies based on unique user plays
                 var topMovies = GetTopMovies(topCount, users, cutoffDate);
@@ -245,7 +245,7 @@ namespace Jellyfin.Plugin.TopTen.ScheduledTasks
                     // Sum up play counts from all episodes within the cutoff period
                     foreach (var episode in episodes)
                     {
-                        foreach (var user in _userManager.Users)
+                        foreach (var user in _userManager.GetUsers())
                         {
                             var userData = _userDataManager.GetUserData(user, episode);
                             

--- a/Jellyfin.Plugin.TopTen/ScheduledTasks/TopTenCollectionTask.cs
+++ b/Jellyfin.Plugin.TopTen/ScheduledTasks/TopTenCollectionTask.cs
@@ -219,7 +219,8 @@ namespace Jellyfin.Plugin.TopTen.ScheduledTasks
 
                 // Create PlaybackInfo objects for each series
                 var seriesPlaybackInfo = new Dictionary<Guid, PlaybackInfo>();
-                
+                var users = _userManager.GetUsers().ToList();
+
                 foreach (var s in series)
                 {
                     var playbackInfo = new PlaybackInfo
@@ -245,7 +246,7 @@ namespace Jellyfin.Plugin.TopTen.ScheduledTasks
                     // Sum up play counts from all episodes within the cutoff period
                     foreach (var episode in episodes)
                     {
-                        foreach (var user in _userManager.GetUsers())
+                        foreach (var user in users)
                         {
                             var userData = _userDataManager.GetUserData(user, episode);
                             


### PR DESCRIPTION
## Summary
- `IUserManager.Users` property was removed in Jellyfin 10.11.10, replaced by `GetUsers()` method
- Updated both call sites in `TopTenCollectionTask.cs` to use `GetUsers()`
- Bumped `Jellyfin.Controller` and `Jellyfin.Model` NuGet references from 10.11.0 to 10.11.10

Fixes #5

## Test plan
- [x] Built locally against 10.11.10 NuGet packages — 0 errors
- [x] Deployed to Umbrel Jellyfin (10.11.10) — plugin loads successfully
- [x] Triggered "Update Top Ten Collection" scheduled task — runs without MissingMethodException